### PR TITLE
Support data I/O options: context, ignore-label, map-label

### DIFF
--- a/io_func/__init__.py
+++ b/io_func/__init__.py
@@ -1,6 +1,7 @@
 import os.path
 import gzip
 import bz2
+import numpy
 
 def smart_open(filename, mode = 'rb', *args, **kwargs):
     '''
@@ -18,3 +19,46 @@ def smart_open(filename, mode = 'rb', *args, **kwargs):
                 break
     extension = os.path.splitext(filename)[1]
     return readers.get(extension, open)(filename, mode, *args, **kwargs)
+
+def make_context(feature, left, right):
+    '''
+    Takes a 2-D numpy feature array, and pads each frame with a specified
+        number of frames on either side.
+    '''
+    feature = [feature]
+    for i in range(left):
+        feature.append(numpy.vstack((feature[-1][0], feature[-1][:-1])))
+    feature.reverse()
+    for i in range(right):
+        feature.append(numpy.vstack((feature[-1][1:], feature[-1][-1])))
+    return numpy.hstack(feature)
+
+def preprocess_feature_and_label(feature, label, opts):
+    '''
+    Apply the options 'context', 'ignore-label', 'map-label' to the feature
+        matrix and label vector.
+    '''
+
+    feature = make_context(feature, opts['lcxt'], opts['rcxt'])
+
+    if label is not None:
+        if opts.has_key('ignore-label'):
+            ignore = opts['ignore-label']
+            mask = numpy.array([x not in ignore for x in label])
+            feature = feature[mask]
+            label = label[mask]
+        if opts.has_key('map-label'):
+            map = opts['map-label']
+            label = numpy.array([map.get(x, x) for x in label])
+
+    return feature, label
+
+def shuffle_feature_and_label(feature, label):
+    '''
+    Randomly shuffles features and labels in the *same* order.
+    '''
+    seed = 18877
+    numpy.random.seed(seed)
+    numpy.random.shuffle(feature)
+    numpy.random.seed(seed)
+    numpy.random.shuffle(label)

--- a/io_func/pickle_io.py
+++ b/io_func/pickle_io.py
@@ -23,7 +23,7 @@ import theano
 import theano.tensor as T
 from utils.utils import string_2_bool
 from model_io import log
-from io_func import smart_open
+from io_func import smart_open, preprocess_feature_and_label, shuffle_feature_and_label
 
 class PickleDataRead(object):
 
@@ -49,13 +49,13 @@ class PickleDataRead(object):
             fopen.close()
             shared_x, shared_y = shared_xy
 
-            if self.read_opts['random']:  # randomly shuffle features and labels in the *same* order
-                numpy.random.seed(18877)
-                numpy.random.shuffle(self.feat_mat)
-                numpy.random.seed(18877)
-                numpy.random.shuffle(self.label_vec)
+            self.feat_mat, self.label_vec = \
+                preprocess_feature_and_label(self.feat_mat, self.label_vec, self.read_opts)
+            if self.read_opts['random']:
+                shuffle_feature_and_label(self.feat_mat, self.label_vec)
+
             shared_x.set_value(self.feat_mat, borrow=True)
-            shared_y.set_value(self.label_vec.astype(numpy.float32), borrow=True)
+            shared_y.set_value(self.label_vec.astype(theano.config.floatX), borrow=True)
 
         self.cur_frame_num = len(self.feat_mat)
         self.cur_pfile_index += 1

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -18,10 +18,7 @@ from learn_rates import LearningRateConstant, LearningRateExpDecay, LearningMinL
 from io_func import smart_open
 
 def string_2_bool(string):
-    if string == 'true':
-        return True
-    if string == 'false':
-        return False
+    return len(string) > 0 and string[0] in 'TtYy'      # True, true, Yes, yes
 
 def parse_arguments(arg_elements):
     args = {}
@@ -125,7 +122,7 @@ def parse_activation(act_str):
         return T.nnet.sigmoid
     if act_str == 'tanh':
         return T.tanh
-    if act_str == 'rectifier':
+    if act_str == 'rectifier' or act_str == 'relu':
         return lambda x: T.maximum(0.0, x)
     return T.nnet.sigmoid
 


### PR DESCRIPTION
Hi Yajie,

  I have implemented the options "context", "ignore-label", and "map-label" when reading any data format.

  Suppose you have a "train.pfile" with 10 classes (0~9), and you want to do the following things:
    * Treat the classes 3,4,5 as one class, and class 6 as the other;
    * Train a classifier for the two classes defined above, and ignore all other classes;
    * Pad all the features with 5 frames on both sides.
  You can specify --train-data "train.pfile,context=5,ignore-label=0-2:7-9,map-label=3-5:0/6:1" to achieve what you want.

  Here, "context=5" can be replaced by "context=5:5" (specifying the left and right contexts separately), or "lcxt=5,rcxt=5" (as you originally supported for Kaldi feature files).

  The usage of punctuation marks is rather messy, but it can be summarized as:
    * Commas are used to separate options;
    * Colons are used to separate numbers in values of options;
      - But in "map-label", slashes are used to separate mappings, and colons are used to separate the original and mapped labels;
    * Dashes are used to denote a range of labels.

  I tried to make my implementation compatible with everything pre-existing (e.g. both stream and non-stream mode of pfile reading). I have tested my implementation with pickle files and pfiles, but not with Kaldi files; if you have some Kaldi files, you may test it out.